### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,10 +5,9 @@ generator client {
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("VITE_POSTGRES_PRISMA_URL")
-  directUrl         = env("VITE_POSTGRES_URL_NON_POOLING")
-  shadowDatabaseUrl = env("VITE_POSTGRES_URL_NON_POOLING")
+  provider  = "postgresql"
+  url       = env("VITE_POSTGRES_PRISMA_URL")
+  directUrl = env("VITE_POSTGRES_URL_NON_POOLING")
 }
 
 model Meta {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.